### PR TITLE
Fixes for Chez Scheme

### DIFF
--- a/codatatypes.sls
+++ b/codatatypes.sls
@@ -5,12 +5,8 @@
         )
 (import (except (rnrs) member)
         (srfi :45)
-        (only (srfi :1) member count))
-
-(define registry
-  (make-hashtable (lambda (x)
-                    (equal-hash (syntax->datum x)))
-                  free-identifier=?))
+        (only (srfi :1) member count)
+        (for (ijputils private codatatypes) expand))
 
 (define-syntax define-codatatype
   (lambda (stx)

--- a/functions.sls
+++ b/functions.sls
@@ -23,6 +23,7 @@
         eta*
         )
 (import (rnrs base)
+        (rnrs lists)
         (only (ijputils common) define-syntax-rule))
 
 (define (compose . funs)

--- a/private/codatatypes.sls
+++ b/private/codatatypes.sls
@@ -1,0 +1,10 @@
+#!r6rs
+(library (ijputils private codatatypes)
+(export registry
+        )
+(import (rnrs))
+
+(define registry
+  (make-hashtable (lambda (x)
+                    (equal-hash (syntax->datum x)))
+                  free-identifier=?)))


### PR DESCRIPTION
Hello Ian,

I have some fixes for running this code on Chez Scheme. Please consider reviewing them.

The functions library was missing for-all from the imports and codatatypes used an out of phase identifier for the registry.